### PR TITLE
feat: add Ontology module

### DIFF
--- a/docs/src/ontologies.md
+++ b/docs/src/ontologies.md
@@ -1,0 +1,45 @@
+# Ontologies
+ 
+The Ontology Lookup Service (OLS) is designed to leverage the power of multiple ontologies, providing a structured and semantic framework for organizing, interpreting, and querying data across various domains.
+
+The OLS provides access to a wide range of ontologies, including the following:
+- [ChEBI](https://www.ebi.ac.uk/chebi/)
+- [GO](http://geneontology.org/)
+- [NCBITaxon](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi)
+- [PR](https://proconsortium.org/)
+- [UBERON](http://uberon.github.io/)
+- [EFO](https://www.ebi.ac.uk/efo/)
+
+The OLS also provides access to the following cross-domain ontologies:
+- [OBO](http://obofoundry.org/)
+- [EDAM](https://edamontology.org/)
+
+
+And many more. The OLS is designed to be extensible, allowing users to add their own ontologies to the system.
+
+# Listing ontologies
+
+To list all available ontologies, use the following command:
+
+```julia
+list_ontologies()
+```
+
+This will return a list of all available ontologies in the OLS.
+
+Note, this will return Ontology objects, which contain information about the ontology, such as the name, title, description, and version. If you wish to only get the ids of the ontologies, you can use the following command:
+
+```julia
+list_ontology_ids()
+```
+
+# Getting an ontology
+
+To get information about a specific ontology, use the following command:
+
+```julia
+get_ontology("CHEBI")
+```
+
+
+

--- a/docs/src/ontologies.md
+++ b/docs/src/ontologies.md
@@ -42,4 +42,11 @@ get_ontology("CHEBI")
 ```
 
 
+# References
+
+```@autodocs
+Modules = [OntologyLookup.Ontologies]
+```
+
+
 

--- a/src/OntologyLookup.jl
+++ b/src/OntologyLookup.jl
@@ -17,6 +17,10 @@ include("term_controller.jl")
 using .TermController
 export onto_terms, onto_term, get_parents, get_hierarchical_parent
 
+include("ontologies.jl")
+using .Ontologies
+export Ontology, list_ontologies, list_ontologies_ids, get_ontology
+
 function __init__()
 end
 

--- a/src/ontologies.jl
+++ b/src/ontologies.jl
@@ -1,0 +1,120 @@
+module Ontologies
+
+using JSON3
+
+import ..OntologyLookup: Client, OLS_BASE_URL
+
+export Ontology, list_ontologies, list_ontologies_ids, get_ontology
+
+@kwdef struct Ontology
+    language::String
+    available_languages::Vector{String}
+    ontology_id::String
+    version::Union{Nothing,String}
+    number_of_terms::Int
+    number_of_properties::Int
+end
+
+function Base.show(io::IO, ontology::Ontology)
+    println(io, "Ontology:")
+    println(io, "  Ontology ID: ", ontology.ontology_id)
+    println(io, "  Language: ", ontology.language)
+    println(io, "  Available Languages: ", join(ontology.available_languages, ", "))
+    println(io, "  Version: ", ontology.version)
+    println(io, "  Number of Terms: ", ontology.number_of_terms)
+    return println(io, "  Number of Properties: ", ontology.number_of_properties)
+end
+
+"""
+    list_ontologies()::Union{Vector{Ontology},Missing}
+
+Fetches a list of ontologies from the OLS (Ontology Lookup Service) API.
+
+# Returns
+- If successful, returns a vector of `Ontology` objects representing the fetched ontologies.
+- If an error occurs during the API request, returns `missing`.
+
+# See also 
+- [`list_ontologies_ids()`](@ref)
+- [`get_ontology()`](@ref)
+"""
+function list_ontologies()::Union{Vector{Ontology},Missing}
+    url = OLS_BASE_URL * "ontologies"
+    data = try
+        response = Client.get(url)
+        body = JSON3.read(String(response.body), Dict)
+        data = body["_embedded"]["ontologies"]
+        ontologies = [Ontology(;
+                               language=ontology["lang"],
+                               available_languages=ontology["languages"],
+                               ontology_id=ontology["ontologyId"],
+                               version=ontology["version"],
+                               number_of_terms=ontology["numberOfTerms"],
+                               number_of_properties=ontology["numberOfProperties"])
+                      for ontology in data]
+        return ontologies
+    catch e
+        @error e
+        @warn "Error fetching ontologies. Returning missing."
+        return missing
+    end
+    return data
+end
+
+"""
+    list_ontologies_ids()::Union{Vector{String},Missing}
+
+Returns a vector of ontology IDs.
+
+Retrieve the list of available ontologies, and returns a vector of their IDs. 
+If an error occurs during the fetch, the function returns `missing`.
+
+# See also 
+- [`list_ontologies()`](@ref)
+- [`get_ontology()`](@ref)
+
+"""
+function list_ontologies_ids()::Union{Vector{String},Missing}
+    ontologies = list_ontologies()
+    if ontologies === missing
+        return missing
+    end
+    return [ontology.ontology_id for ontology in ontologies]
+end
+
+"""
+    get_ontology(ontology_id::String)::Union{Ontology,Missing}
+
+Fetches an ontology from the OLS (Ontology Lookup Service) based on the given `ontology_id`. 
+To get a list of available ontologies, use the `list_ontologies()` function.
+
+# Returns
+- If the ontology is found, returns an `Ontology` object containing information about the ontology.
+- If the ontology is not found or an error occurs during the fetch, returns `missing`.
+
+# See also 
+- [`list_ontologies()`](@ref)
+- [`list_ontologies_ids()`](@ref)
+"""
+function get_ontology(ontology_id::String)::Union{Ontology,Missing}
+    url = OLS_BASE_URL * "ontologies/" * ontology_id
+    data = try
+        response = Client.get(url)
+        body = JSON3.read(String(response.body), Dict)
+        ontology = Ontology(;
+                            language=body["lang"],
+                            available_languages=body["languages"],
+                            ontology_id=body["ontologyId"],
+                            version=body["version"],
+                            number_of_terms=body["numberOfTerms"],
+                            number_of_properties=body["numberOfProperties"])
+        return ontology
+    catch e
+        @error e
+        @warn "Error fetching ontology with ID: $ontology_id. Returning missing."
+        return missing
+    end
+    return data
+end
+
+end # module

--- a/test/test_ontologies.jl
+++ b/test/test_ontologies.jl
@@ -1,0 +1,24 @@
+# Test list_ontologies()
+@testitem "list_ontologies()" begin
+    ontologies = list_ontologies()
+    @test !isempty(ontologies)
+    @test typeof(ontologies) == Vector{OntologyLookup.Ontology}
+end
+
+# Test list_ontologies_ids()
+@testitem "list_ontologies_ids()" begin
+    ontologies = list_ontologies_ids()
+    @test !isempty(ontologies)
+    @test typeof(ontologies) == Vector{String}
+end
+
+# Test get_ontology()
+@testitem "get_ontology()" begin
+    ontologies = list_ontologies()
+    if !isempty(ontologies)
+        ontology_id = ontologies[1].ontology_id
+        @test_throws MethodError get_ontology()
+        @test !ismissing(get_ontology(ontology_id))
+        @test typeof(get_ontology(ontology_id)) == OntologyLookup.Ontology
+    end
+end


### PR DESCRIPTION
this module allows for listing all available ontologies from OLS and provides three new method to do so list_ontologies, list_ontologies_ids, and get_ontology()